### PR TITLE
fix:heroku pushでエラーのためGemfileにrubyのバージョンを明記

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+ruby '3.2.3'
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 8.0.0"
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]


### PR DESCRIPTION
git push heroku mainでエラールビーのバージョンが3.1.6はactivesupport-8.0.0に対応しないとのエラーが出たためGemfileにruby '3.2.3'を追加。