### PR TITLE
database.ymlのcable設定を追加

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -54,3 +54,6 @@ production:
   username: <%= ENV['DATABASE_USERNAME'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>
   url: <%= ENV['DATABASE_URL'] %>
+  cable:
+    <<: *default
+    url: <%= ENV['DATABASE_URL'] %>


### PR DESCRIPTION
Herokuデプロイ時にcableの設定がないエラーが出ていたので
datebase.yamlにcamleの設定を追加しました。