### PR TITLE
feature/マイページとグループページのbodyのレイアウト変更

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -11,6 +11,12 @@
   height: 100vh; // 背景が全画面に表示
 }
 
+.title {
+  font-family: 'Century', serif;
+  font-size: 2rem; /* 必要に応じてサイズを変更 */
+  font-weight: bold; /* フォントの太さを変更 */
+}
+
 
 
 header {
@@ -41,7 +47,7 @@ header {
 }
 
 body {
-  padding-top: 60px; // ヘッダーの高さに合わせて余白を確保
+  padding-top: 90px; // ヘッダーの高さに合わせて余白を確保
   min-height: 700px;
 }
 

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,6 +1,6 @@
-<h1><%= "#{@group.name}のグループページ" %></h1>
-<%= link_to 'マイページに戻る', user_path(current_user), class: 'btn btn-primary' %>
-<%= button_to 'キャンプギア読み込み', initialize_my_gears_group_path(@group),data: { turbo_method: :post} %>
+<h1 class="text-center title"><%= "#{@group.name}のGroup page" %></h1> <!-- titleはscssに定義 -->
+<%= button_to 'キャンプギア読み込み', initialize_my_gears_group_path(@group),data: { turbo_method: :post}, class: 'btn btn-outline-dark' %>
+
 <ul class="nav nav-tabs" id="myTab" role="tablist">
   <li class="nav-item" role="presentation">
     <button class="nav-link active" id="information-tab" data-bs-toggle="tab" data-bs-target="#information-tab-pane" type="button" role="tab" aria-controls="information-tab-pane" aria-selected="true">基本情報</button>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,7 @@
 <%= notice %>
-<h1>Mypage</h1>
-<%= @name %>
-<%= link_to "Logout", :logout, class: "me-3" %>
+
+<h1 class="text-center title">My page</h1> <!-- titleはscssに定義 -->
+
 
 
 <ul class="nav nav-tabs" id="myTab" role="tablist">


### PR DESCRIPTION
・application.bootstrap.scssにtitleを定義してマイページとグループページのタイトルに適応させフォントをsenturyに変更しました。
・グループページにあったマイページへ戻るボタンはヘッダーと重複するため削除しました
・マイページにあったログアウトボタンはヘッダーと重複するため削除しました