### PR TITLE
fix/マイページキャンプギア削除を正常化

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
-
   # private
   # def not_authenticated
   # redirect_to login_path, alert: "Please login first"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,9 +19,8 @@
   <head>
     <div class="container d-flex justify-content-between align-items-center">
       
-      <nav>
-        
-      </nav>
+      <%= csrf_meta_tags %>
+      <%= csp_meta_tag %>
     </div>
 
     <%= yield :head %>


### PR DESCRIPTION
・ユーザーを作成し、マイページでキャンプギアを作成しそれを削除するとhttp 422エラーが出現しCSRFトークンが不足していましたのでapplication.html.erbにCSRFトークンを設定しました