### PR TITLE
fix/候補地投稿作成後のリダイレクト

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -25,10 +25,9 @@ class PostsController < ApplicationController
     end
 
     def create
-      @post = Post.new(post_params)
-      @post.group_id = params[:group_id]
+      @post = @group.posts.new(post_params) # set_group を利用して @group を使う
       if @post.save
-        redirect_to group_path(@post.group_id), notice: "候補を投稿しました"
+        redirect_to @group, notice: "候補を投稿しました"
       else
         Rails.logger.error(@post.errors.full_messages)
         render "new"


### PR DESCRIPTION
・本番環境でキャンプ候補地作成後のリダイレクトがエラーになっていたのでpost.controllerのcreateのリダイレクトを修正しました