### PR TITLE
fix/基本情報作成修正

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -29,11 +29,6 @@ class GroupsController < ApplicationController
     @mygears = @group.my_gears.where(user: current_user).includes(:gear)
     mygear_gear_ids = @mygears.pluck(:gear_id) # すでにMygearに登録済みのGear ID
     @available_gears = current_user.gears.where.not(id: mygear_gear_ids) # 未登録のGear
-    @events = Array(@information).flat_map do |info|
-      (info.start_day.to_date..info.finish_day.to_date).map do |date|
-        OpenStruct.new(start_time: date, info: info)
-      end
-    end
 
     # グループ全体の MyGear を取得
     @group_my_gears = MyGear.includes(:gear, :user).where(group: @group)

--- a/app/views/informations/index.html.erb
+++ b/app/views/informations/index.html.erb
@@ -20,14 +20,6 @@
               </div>
             <% end %>
           <% end %>
-
-          <% informations.each do |info| %>
-            <% if info.finish_day.present? && date == info.finish_day.to_date %>
-              <div class="event">
-                終了日
-              </div>
-            <% end %>
-          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/informations/new.html.erb
+++ b/app/views/informations/new.html.erb
@@ -5,7 +5,7 @@
       <div class='mb-3'>
         <%= f.label :start_day, '出発日', class: 'form-label d-block' %> <!-- ラベルを中央揃え -->
         <div class="d-flex justify-content-center">
-          <%= f.text_field :start_day, class: 'form-control', style: "max-width: 300px;" %>
+          <%= f.date_select :start_day, class: 'form-control', style: "max-width: 300px;" %>
         </div>
       </div>
     


### PR DESCRIPTION
・基本情報ページが作成できないエラーを解消しました
・今は使われていないシンプルカレンダーへ代入する変数が定義されていてエラーを起こしていたので削除しました。
・基本情報の出発日の入力がtextになっていたのでselect型に変更しました